### PR TITLE
Compatibility with Neovim terminal version

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,11 +1,16 @@
 This is a version of https://github.com/altercation/vim-colors-solarized
 modified to always use true color (24 bit rgb). This means it will work with
-neovim with the following:
+neovim-qt with the following:
+
+In file `~/.config/nvim/ginit.vim` :
 
     let $NVIM_TUI_ENABLE_TRUE_COLOR=1
     set background=light " or dark
+    colorscheme solarized_nvimqt
+    
+For Neovim terminal version, in file `~/.config/nvim/init.vim`, keep :
+    
+    set background=light " or dark
     colorscheme solarized
-
-Normally this wouldn't work with neovim (as of writing) since `gui_running` is always false during initialisation.
 
 For more info see the original.

--- a/colors/solarized_nvimqt.vim
+++ b/colors/solarized_nvimqt.vim
@@ -1,17 +1,9 @@
-" Name:     Solarized vim colorscheme
-" Author:   Ethan Schoonover <es@ethanschoonover.com>
-" URL:      http://ethanschoonover.com/solarized
-"           (see this url for latest release & screenshots)
-" License:  OSI approved MIT license (see end of this file)
-" Created:  In the middle of the night
-" Modified: 2011 May 05
-"
 " Usage "{{{
 "
 " ---------------------------------------------------------------------
 " ABOUT:
 " ---------------------------------------------------------------------
-" Solarized is a carefully designed selective contrast colorscheme with dual
+" Solarizednvimqt is a carefully designed selective contrast colorscheme with dual
 " light and dark modes that runs in both GUI, 256 and 16 color modes.
 "
 " See the homepage above for screenshots and details.
@@ -19,10 +11,10 @@
 " ---------------------------------------------------------------------
 " OPTIONS:
 " ---------------------------------------------------------------------
-" See the "solarized.txt" help file included with this colorscheme (in the 
+" See the "solarized_nvimqt.txt" help file included with this colorscheme (in the 
 " "doc" subdirectory) for information on options, usage, the Toggle Background 
-" function and more. If you have already installed Solarized, this is available 
-" from the Solarized menu and command line as ":help solarized"
+" function and more. If you have already installed Solarizednvimqt, this is available 
+" from the Solarizednvimqt menu and command line as ":help solarized_nvimqt"
 "
 " ---------------------------------------------------------------------
 " INSTALLATION:
@@ -32,9 +24,9 @@
 " MANUAL INSTALLATION OPTION:
 " ---------------------------------------------------------------------
 "
-" 1.  Download the solarized distribution (available on the homepage above)
+" 1.  Download the solarized_nvimqt distribution (available on the homepage above)
 "     and unarchive the file.
-" 2.  Move `solarized.vim` to your `.vim/colors` directory.
+" 2.  Move `solarized_nvimqt.vim` to your `.vim/colors` directory.
 " 3.  Move each of the files in each subdirectories to the corresponding .vim
 "     subdirectory (e.g. autoload/togglebg.vim goes into your .vim/autoload 
 "     directory as .vim/autoload/togglebg.vim).
@@ -45,18 +37,18 @@
 " 1.  Download and install Tim Pope's Pathogen from:
 "     https://github.com/tpope/vim-pathogen
 "
-" 2.  Next, move or clone the `vim-colors-solarized` directory so that it is
+" 2.  Next, move or clone the `vim-colors-solarized_nvimqt` directory so that it is
 "     a subdirectory of the `.vim/bundle` directory.
 "
 "     a. **clone with git:**
 "
 "       $ cd ~/.vim/bundle
-"       $ git clone git://github.com/altercation/vim-colors-solarized.git
+"       $ git clone git://github.com/altercation/vim-colors-solarized_nvimqt.git
 "
 "     b. **or move manually into the pathogen bundle directory:**
-"         In the parent directory of vim-colors-solarized:
+"         In the parent directory of vim-colors-solarized_nvimqt:
 "
-"         $ mv vim-colors-solarized ~/.vim/bundle/
+"         $ mv vim-colors-solarized_nvimqt ~/.vim/bundle/
 "
 " MODIFY VIMRC:
 "
@@ -65,13 +57,13 @@
 "
 "     syntax enable
 "     set background=dark
-"     colorscheme solarized
+"     colorscheme solarized_nvimqt
 "
-" or, for the light background mode of Solarized:
+" or, for the light background mode of Solarizednvimqt:
 "
 "     syntax enable
 "     set background=light
-"     colorscheme solarized
+"     colorscheme solarized_nvimqt
 "
 " I like to have a different background in GUI and terminal modes, so I can use
 " the following if-then. However, I find vim's background autodetection to be
@@ -84,13 +76,13 @@
 "       set background=dark
 "     endif
 "
-" See the Solarized homepage at http://ethanschoonover.com/solarized for
+" See the Solarizednvimqt homepage at http://ethanschoonover.com/solarized_nvimqt for
 " screenshots which will help you select either the light or dark background.
 "
 " ---------------------------------------------------------------------
 " COLOR VALUES
 " ---------------------------------------------------------------------
-" Download palettes and files from: http://ethanschoonover.com/solarized
+" Download palettes and files from: http://ethanschoonover.com/solarized_nvimqt
 "
 " L\*a\*b values are canonical (White D65, Reference D50), other values are
 " matched in sRGB space.
@@ -140,22 +132,22 @@ let s:terminal_italic=1
 " Default option values"{{{
 " ---------------------------------------------------------------------
 " s:options_list is used to autogenerate a list of all non-default options 
-" using "call SolarizedOptions()" or with the "Generate .vimrc commands" 
-" Solarized menu option. See the "Menus" section below for the function itself.
+" using "call SolarizednvimqtOptions()" or with the "Generate .vimrc commands" 
+" Solarizednvimqt menu option. See the "Menus" section below for the function itself.
 let s:options_list=[
-            \'" this block of commands has been autogenerated by solarized.vim and',
-            \'" includes the current, non-default Solarized option values.',
+            \'" this block of commands has been autogenerated by solarized_nvimqt.vim and',
+            \'" includes the current, non-default Solarizednvimqt option values.',
             \'" To use, place these commands in your .vimrc file (replacing any',
-            \'" existing colorscheme commands). See also ":help solarized"',
+            \'" existing colorscheme commands). See also ":help solarized_nvimqt"',
             \'',
             \'" ------------------------------------------------------------------',
-            \'" Solarized Colorscheme Config',
+            \'" Solarizednvimqt Colorscheme Config',
             \'" ------------------------------------------------------------------',
             \]
 let s:colorscheme_list=[
             \'syntax enable',
             \'set background='.&background,
-            \'colorscheme solarized',
+            \'colorscheme solarized_nvimqt',
             \]
 let s:defaults_list=[
             \'" ------------------------------------------------------------------',
@@ -177,20 +169,20 @@ function! s:SetOption(name,default)
         let l:wrap='"'
         let l:ewrap='\"'
     endif
-    if !exists("g:solarized_".a:name) || g:solarized_{a:name}==a:default
-        exe 'let g:solarized_'.a:name.'='.l:wrap.a:default.l:wrap.'"'
-        exe 'call add(s:defaults_list, "\" let g:solarized_'.a:name.'='.l:ewrap.g:solarized_{a:name}.l:ewrap.'")'
+    if !exists("g:solarized_nvimqt_".a:name) || g:solarized_nvimqt_{a:name}==a:default
+        exe 'let g:solarized_nvimqt_'.a:name.'='.l:wrap.a:default.l:wrap.'"'
+        exe 'call add(s:defaults_list, "\" let g:solarized_nvimqt_'.a:name.'='.l:ewrap.g:solarized_nvimqt_{a:name}.l:ewrap.'")'
     else
-        exe 'call add(s:options_list,  "let g:solarized_'.a:name.'='.l:ewrap.g:solarized_{a:name}.l:ewrap.'    \"default value is '.a:default.'")'
+        exe 'call add(s:options_list,  "let g:solarized_nvimqt_'.a:name.'='.l:ewrap.g:solarized_nvimqt_{a:name}.l:ewrap.'    \"default value is '.a:default.'")'
     endif
 endfunction
 
 if ($TERM_PROGRAM ==? "apple_terminal" && &t_Co < 256)
-    let s:solarized_termtrans_default = 1
+    let s:solarized_nvimqt_termtrans_default = 1
 else
-    let s:solarized_termtrans_default = 0
+    let s:solarized_nvimqt_termtrans_default = 0
 endif
-call s:SetOption("termtrans",s:solarized_termtrans_default)
+call s:SetOption("termtrans",s:solarized_nvimqt_termtrans_default)
 call s:SetOption("degrade",0)
 call s:SetOption("bold",1)
 call s:SetOption("underline",1)
@@ -209,7 +201,7 @@ hi clear
 if exists("syntax_on")
   syntax reset
 endif
-let colors_name = "solarized"
+let colors_name = "solarized_nvimqt"
 
 "}}}
 " GUI & CSApprox hexadecimal palettes"{{{
@@ -218,9 +210,9 @@ let colors_name = "solarized"
 " Set both gui and terminal color values in separate conditional statements
 " Due to possibility that CSApprox is running (though I suppose we could just
 " leave the hex values out entirely in that case and include only cterm colors)
-" We also check to see if user has set solarized (force use of the
+" We also check to see if user has set solarized_nvimqt (force use of the
 " neutral gray monotone palette component)
-if (g:solarized_degrade == 0)
+if (g:solarized_nvimqt_degrade == 0)
     let s:vmode       = "gui"
     let s:base03      = "#002b36"
     let s:base02      = "#073642"
@@ -239,9 +231,9 @@ if (g:solarized_degrade == 0)
     let s:cyan        = "#2aa198"
     "let s:green       = "#859900" "original
     let s:green       = "#719e07" "experimental
-elseif (g:solarized_degrade == 1)
+elseif (g:solarized_nvimqt_degrade == 1)
     " These colors are identical to the 256 color mode. They may be viewed
-    " while in gui mode via "let g:solarized_degrade=1", though this is not
+    " while in gui mode via "let g:solarized_nvimqt_degrade=1", though this is not
     " recommened and is for testing only.
     let s:vmode       = "gui"
     let s:base03      = "#1c1c1c"
@@ -276,7 +268,7 @@ endif
 "}}}
 " Background value based on termtrans setting "{{{
 " ---------------------------------------------------------------------
-if (g:solarized_termtrans == 0)
+if (g:solarized_nvimqt_termtrans == 0)
     let s:back        = s:base03
 else
     let s:back        = "NONE"
@@ -304,7 +296,7 @@ endif
 "}}}
 " Optional contrast schemes "{{{
 " ---------------------------------------------------------------------
-if g:solarized_contrast == "high"
+if g:solarized_nvimqt_contrast == "high"
     let s:base01      = s:base00
     let s:base00      = s:base0
     let s:base0       = s:base1
@@ -312,14 +304,14 @@ if g:solarized_contrast == "high"
     let s:base2       = s:base3
     let s:back        = s:back
 endif
-if g:solarized_contrast == "low"
+if g:solarized_nvimqt_contrast == "low"
     let s:back        = s:base02
     let s:ou          = ",underline"
 endif
 "}}}
 " Overrides dependent on user specified values and environment "{{{
 " ---------------------------------------------------------------------
-if (g:solarized_bold == 0 || &t_Co == 8 )
+if (g:solarized_nvimqt_bold == 0 || &t_Co == 8 )
     let s:b           = ""
     let s:bb          = ",bold"
 else
@@ -327,13 +319,13 @@ else
     let s:bb          = ""
 endif
 
-if g:solarized_underline == 0
+if g:solarized_nvimqt_underline == 0
     let s:u           = ""
 else
     let s:u           = ",underline"
 endif
 
-if g:solarized_italic == 0 || s:terminal_italic == 0
+if g:solarized_nvimqt_italic == 0 || s:terminal_italic == 0
     let s:i           = ""
 else
     let s:i           = ",italic"
@@ -486,10 +478,10 @@ exe "hi! Todo"           .s:fmt_bold   .s:fg_magenta.s:bg_none
 "}}}
 " Extended highlighting "{{{
 " ---------------------------------------------------------------------
-if      (g:solarized_visibility=="high")
+if      (g:solarized_nvimqt_visibility=="high")
     exe "hi! SpecialKey" .s:fmt_revr   .s:fg_red    .s:bg_none
     exe "hi! NonText"    .s:fmt_bold   .s:fg_red    .s:bg_none
-elseif  (g:solarized_visibility=="low")
+elseif  (g:solarized_nvimqt_visibility=="low")
     exe "hi! SpecialKey" .s:fmt_bold   .s:fg_base02 .s:bg_none
     exe "hi! NonText"    .s:fmt_bold   .s:fg_base02 .s:bg_none
 else
@@ -514,12 +506,12 @@ exe "hi! WarningMsg"     .s:fmt_bold   .s:fg_red    .s:bg_none
 exe "hi! WildMenu"       .s:fmt_none   .s:fg_base2  .s:bg_base02 .s:fmt_revbb
 exe "hi! Folded"         .s:fmt_undb   .s:fg_base0  .s:bg_base02  .s:sp_base03
 exe "hi! FoldColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02
-if      (g:solarized_diffmode=="high")
+if      (g:solarized_nvimqt_diffmode=="high")
 exe "hi! DiffAdd"        .s:fmt_revr   .s:fg_green  .s:bg_none
 exe "hi! DiffChange"     .s:fmt_revr   .s:fg_yellow .s:bg_none
 exe "hi! DiffDelete"     .s:fmt_revr   .s:fg_red    .s:bg_none
 exe "hi! DiffText"       .s:fmt_revr   .s:fg_blue   .s:bg_none
-elseif  (g:solarized_diffmode=="low")
+elseif  (g:solarized_nvimqt_diffmode=="low")
 exe "hi! DiffAdd"        .s:fmt_undr   .s:fg_green  .s:bg_none   .s:sp_green
 exe "hi! DiffChange"     .s:fmt_undr   .s:fg_yellow .s:bg_none   .s:sp_yellow
 exe "hi! DiffDelete"     .s:fmt_bold   .s:fg_red    .s:bg_none
@@ -849,12 +841,12 @@ hi! link pandocMetadataTitle             pandocMetadata
 "}}}
 " Utility autocommand "{{{
 " ---------------------------------------------------------------------
-" In cases where Solarized is initialized inside a terminal vim session and 
+" In cases where Solarizednvimqt is initialized inside a terminal vim session and 
 " then transferred to a gui session via the command `:gui`, the gui vim process 
 " does not re-read the colorscheme (or .vimrc for that matter) so any `has_gui` 
 " related code that sets gui specific values isn't executed.
 "
-" Currently, Solarized sets only the cterm or gui values for the colorscheme 
+" Currently, Solarizednvimqt sets only the cterm or gui values for the colorscheme 
 " depending on gui or terminal mode. It's possible that, if the following 
 " autocommand method is deemed excessively poor form, that approach will be 
 " used again and the autocommand below will be dropped.
@@ -868,29 +860,29 @@ autocmd GUIEnter * if (s:vmode != "gui") | exe "colorscheme " . g:colors_name | 
 "}}}
 " Highlight Trailing Space {{{
 " Experimental: Different highlight when on cursorline
-function! s:SolarizedHiTrail()
-    if g:solarized_hitrail==0
-        hi! clear solarizedTrailingSpace
+function! s:SolarizednvimqtHiTrail()
+    if g:solarized_nvimqt_hitrail==0
+        hi! clear solarized_nvimqtTrailingSpace
     else
-        syn match solarizedTrailingSpace "\s*$"
-        exe "hi! solarizedTrailingSpace " .s:fmt_undr .s:fg_red .s:bg_none .s:sp_red
+        syn match solarized_nvimqtTrailingSpace "\s*$"
+        exe "hi! solarized_nvimqtTrailingSpace " .s:fmt_undr .s:fg_red .s:bg_none .s:sp_red
     endif
 endfunction  
-augroup SolarizedHiTrail
+augroup SolarizednvimqtHiTrail
     autocmd!
-    if g:solarized_hitrail==1
-        autocmd! Syntax * call s:SolarizedHiTrail()
-        autocmd! ColorScheme * if g:colors_name == "solarized" | call s:SolarizedHiTrail() | else | augroup! s:SolarizedHiTrail | endif
+    if g:solarized_nvimqt_hitrail==1
+        autocmd! Syntax * call s:SolarizednvimqtHiTrail()
+        autocmd! ColorScheme * if g:colors_name == "solarized_nvimqt" | call s:SolarizednvimqtHiTrail() | else | augroup! s:SolarizednvimqtHiTrail | endif
     endif
 augroup END
 " }}}
 " Menus "{{{
 " ---------------------------------------------------------------------
-" Turn off Solarized menu by including the following assignment in your .vimrc:
+" Turn off Solarizednvimqt menu by including the following assignment in your .vimrc:
 "
-"    let g:solarized_menu=0
+"    let g:solarized_nvimqt_menu=0
 
-function! s:SolarizedOptions()
+function! s:SolarizednvimqtOptions()
     new "new buffer
     setf vim "vim filetype
     let failed = append(0, s:defaults_list)
@@ -899,72 +891,72 @@ function! s:SolarizedOptions()
     let failed = append(0, s:lazycat_list)
     0 "jump back to the top
 endfunction
-if !exists(":SolarizedOptions")
-    command SolarizedOptions :call s:SolarizedOptions()
+if !exists(":SolarizednvimqtOptions")
+    command SolarizednvimqtOptions :call s:SolarizednvimqtOptions()
 endif
 
-function! SolarizedMenu()
-    if exists("g:loaded_solarized_menu")
+function! SolarizednvimqtMenu()
+    if exists("g:loaded_solarized_nvimqt_menu")
         try
-            silent! aunmenu Solarized
+            silent! aunmenu Solarizednvimqt
         endtry
     endif
-    let g:loaded_solarized_menu = 1
+    let g:loaded_solarized_nvimqt_menu = 1
 
-    if g:colors_name == "solarized" && g:solarized_menu != 0
+    if g:colors_name == "solarized_nvimqt" && g:solarized_nvimqt_menu != 0
 
-        amenu &Solarized.&Contrast.&Low\ Contrast        :let g:solarized_contrast="low"       \| colorscheme solarized<CR>
-        amenu &Solarized.&Contrast.&Normal\ Contrast     :let g:solarized_contrast="normal"    \| colorscheme solarized<CR>
-        amenu &Solarized.&Contrast.&High\ Contrast       :let g:solarized_contrast="high"      \| colorscheme solarized<CR>
-        an    &Solarized.&Contrast.-sep-                 <Nop>
-        amenu &Solarized.&Contrast.&Help:\ Contrast      :help 'solarized_contrast'<CR>
+        amenu &Solarizednvimqt.&Contrast.&Low\ Contrast        :let g:solarized_nvimqt_contrast="low"       \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Contrast.&Normal\ Contrast     :let g:solarized_nvimqt_contrast="normal"    \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Contrast.&High\ Contrast       :let g:solarized_nvimqt_contrast="high"      \| colorscheme solarized_nvimqt<CR>
+        an    &Solarizednvimqt.&Contrast.-sep-                 <Nop>
+        amenu &Solarizednvimqt.&Contrast.&Help:\ Contrast      :help 'solarized_nvimqt_contrast'<CR>
 
-        amenu &Solarized.&Visibility.&Low\ Visibility    :let g:solarized_visibility="low"     \| colorscheme solarized<CR>
-        amenu &Solarized.&Visibility.&Normal\ Visibility :let g:solarized_visibility="normal"  \| colorscheme solarized<CR>
-        amenu &Solarized.&Visibility.&High\ Visibility   :let g:solarized_visibility="high"    \| colorscheme solarized<CR>
-        an    &Solarized.&Visibility.-sep-                 <Nop>
-        amenu &Solarized.&Visibility.&Help:\ Visibility    :help 'solarized_visibility'<CR>
+        amenu &Solarizednvimqt.&Visibility.&Low\ Visibility    :let g:solarized_nvimqt_visibility="low"     \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Visibility.&Normal\ Visibility :let g:solarized_nvimqt_visibility="normal"  \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Visibility.&High\ Visibility   :let g:solarized_nvimqt_visibility="high"    \| colorscheme solarized_nvimqt<CR>
+        an    &Solarizednvimqt.&Visibility.-sep-                 <Nop>
+        amenu &Solarizednvimqt.&Visibility.&Help:\ Visibility    :help 'solarized_nvimqt_visibility'<CR>
 
-        amenu &Solarized.&Background.&Toggle\ Background :ToggleBG<CR>
-        amenu &Solarized.&Background.&Dark\ Background   :set background=dark  \| colorscheme solarized<CR>
-        amenu &Solarized.&Background.&Light\ Background  :set background=light \| colorscheme solarized<CR>
-        an    &Solarized.&Background.-sep-               <Nop>
-        amenu &Solarized.&Background.&Help:\ ToggleBG     :help togglebg<CR>
+        amenu &Solarizednvimqt.&Background.&Toggle\ Background :ToggleBG<CR>
+        amenu &Solarizednvimqt.&Background.&Dark\ Background   :set background=dark  \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Background.&Light\ Background  :set background=light \| colorscheme solarized_nvimqt<CR>
+        an    &Solarizednvimqt.&Background.-sep-               <Nop>
+        amenu &Solarizednvimqt.&Background.&Help:\ ToggleBG     :help togglebg<CR>
 
-        if g:solarized_bold==0 | let l:boldswitch="On" | else | let l:boldswitch="Off" | endif
-        exe "amenu &Solarized.&Styling.&Turn\\ Bold\\ ".l:boldswitch." :let g:solarized_bold=(abs(g:solarized_bold-1)) \\| colorscheme solarized<CR>"
-        if g:solarized_italic==0 | let l:italicswitch="On" | else | let l:italicswitch="Off" | endif
-        exe "amenu &Solarized.&Styling.&Turn\\ Italic\\ ".l:italicswitch." :let g:solarized_italic=(abs(g:solarized_italic-1)) \\| colorscheme solarized<CR>"
-        if g:solarized_underline==0 | let l:underlineswitch="On" | else | let l:underlineswitch="Off" | endif
-        exe "amenu &Solarized.&Styling.&Turn\\ Underline\\ ".l:underlineswitch." :let g:solarized_underline=(abs(g:solarized_underline-1)) \\| colorscheme solarized<CR>"
+        if g:solarized_nvimqt_bold==0 | let l:boldswitch="On" | else | let l:boldswitch="Off" | endif
+        exe "amenu &Solarizednvimqt.&Styling.&Turn\\ Bold\\ ".l:boldswitch." :let g:solarized_nvimqt_bold=(abs(g:solarized_nvimqt_bold-1)) \\| colorscheme solarized_nvimqt<CR>"
+        if g:solarized_nvimqt_italic==0 | let l:italicswitch="On" | else | let l:italicswitch="Off" | endif
+        exe "amenu &Solarizednvimqt.&Styling.&Turn\\ Italic\\ ".l:italicswitch." :let g:solarized_nvimqt_italic=(abs(g:solarized_nvimqt_italic-1)) \\| colorscheme solarized_nvimqt<CR>"
+        if g:solarized_nvimqt_underline==0 | let l:underlineswitch="On" | else | let l:underlineswitch="Off" | endif
+        exe "amenu &Solarizednvimqt.&Styling.&Turn\\ Underline\\ ".l:underlineswitch." :let g:solarized_nvimqt_underline=(abs(g:solarized_nvimqt_underline-1)) \\| colorscheme solarized_nvimqt<CR>"
 
-        amenu &Solarized.&Diff\ Mode.&Low\ Diff\ Mode    :let g:solarized_diffmode="low"     \| colorscheme solarized<CR>
-        amenu &Solarized.&Diff\ Mode.&Normal\ Diff\ Mode :let g:solarized_diffmode="normal"  \| colorscheme solarized<CR>
-        amenu &Solarized.&Diff\ Mode.&High\ Diff\ Mode   :let g:solarized_diffmode="high"    \| colorscheme solarized<CR>
+        amenu &Solarizednvimqt.&Diff\ Mode.&Low\ Diff\ Mode    :let g:solarized_nvimqt_diffmode="low"     \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Diff\ Mode.&Normal\ Diff\ Mode :let g:solarized_nvimqt_diffmode="normal"  \| colorscheme solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Diff\ Mode.&High\ Diff\ Mode   :let g:solarized_nvimqt_diffmode="high"    \| colorscheme solarized_nvimqt<CR>
 
-        if g:solarized_hitrail==0 | let l:hitrailswitch="On" | else | let l:hitrailswitch="Off" | endif
-        exe "amenu &Solarized.&Experimental.&Turn\\ Highlight\\ Trailing\\ Spaces\\ ".l:hitrailswitch." :let g:solarized_hitrail=(abs(g:solarized_hitrail-1)) \\| colorscheme solarized<CR>"
-        an    &Solarized.&Experimental.-sep-               <Nop>
-        amenu &Solarized.&Experimental.&Help:\ HiTrail    :help 'solarized_hitrail'<CR>
+        if g:solarized_nvimqt_hitrail==0 | let l:hitrailswitch="On" | else | let l:hitrailswitch="Off" | endif
+        exe "amenu &Solarizednvimqt.&Experimental.&Turn\\ Highlight\\ Trailing\\ Spaces\\ ".l:hitrailswitch." :let g:solarized_nvimqt_hitrail=(abs(g:solarized_nvimqt_hitrail-1)) \\| colorscheme solarized_nvimqt<CR>"
+        an    &Solarizednvimqt.&Experimental.-sep-               <Nop>
+        amenu &Solarizednvimqt.&Experimental.&Help:\ HiTrail    :help 'solarized_nvimqt_hitrail'<CR>
 
-        an    &Solarized.-sep1-                          <Nop>
+        an    &Solarizednvimqt.-sep1-                          <Nop>
 
-        amenu &Solarized.&Autogenerate\ options          :SolarizedOptions<CR>
+        amenu &Solarizednvimqt.&Autogenerate\ options          :SolarizednvimqtOptions<CR>
 
-        an    &Solarized.-sep2-                          <Nop>
+        an    &Solarizednvimqt.-sep2-                          <Nop>
 
-        amenu &Solarized.&Help.&Solarized\ Help          :help solarized<CR>
-        amenu &Solarized.&Help.&Toggle\ Background\ Help :help togglebg<CR>
-        amenu &Solarized.&Help.&Removing\ This\ Menu     :help solarized-menu<CR>
+        amenu &Solarizednvimqt.&Help.&Solarizednvimqt\ Help          :help solarized_nvimqt<CR>
+        amenu &Solarizednvimqt.&Help.&Toggle\ Background\ Help :help togglebg<CR>
+        amenu &Solarizednvimqt.&Help.&Removing\ This\ Menu     :help solarized_nvimqt-menu<CR>
 
-        an 9999.77 &Help.&Solarized\ Colorscheme         :help solarized<CR>
+        an 9999.77 &Help.&Solarizednvimqt\ Colorscheme         :help solarized_nvimqt<CR>
         an 9999.78 &Help.&Toggle\ Background             :help togglebg<CR>
         an 9999.79 &Help.-sep3-                          <Nop>
 
     endif
 endfunction
 
-autocmd ColorScheme * if g:colors_name != "solarized" | silent! aunmenu Solarized | else | call SolarizedMenu() | endif
+autocmd ColorScheme * if g:colors_name != "solarized_nvimqt" | silent! aunmenu Solarizednvimqt | else | call SolarizednvimqtMenu() | endif
 
 "}}}
 " License "{{{

--- a/doc/solarized_nvimqt.txt
+++ b/doc/solarized_nvimqt.txt
@@ -1,44 +1,44 @@
-*solarized.vim* for Vim version 7.3 or newer. Modified: 2011 May 05
+*solarized_nvimqt.vim* for Vim version 7.3 or newer. Modified: 2011 May 05
 
 
-		Solarized Vim Colorscheme by Ethan Schoonover ~
+		Solarized_nvimqt Vim Colorscheme by Ethan Schoonover ~
 
-Solarized Colorscheme					   *solarized*
-							   *solarized-help*
-							   *solarized-colors*
-							   *solarized-colorscheme*
-							   *vim-colors-solarized*
+Solarized_nvimqt Colorscheme					   *solarized_nvimqt*
+							   *solarized_nvimqt-help*
+							   *solarized_nvimqt-colors*
+							   *solarized_nvimqt-colorscheme*
+							   *vim-colors-solarized_nvimqt*
 
-Solarized is a carefully designed selective contrast colorscheme with dual
+Solarized_nvimqt is a carefully designed selective contrast colorscheme with dual
 light and dark modes that runs in both GUI, 256 and 16 color modes.
 
-See the homepage at http://ethanschoonover.com/solarized for screenshots and 
+See the homepage at http://ethanschoonover.com/solarized_nvimqt for screenshots and 
 details.
 
-0. Install				|solarized-install|
-1. Solarized Menu			|solarized-menu|
-2. Options				|solarized-options|
-3. Toggle Background			|solarized-togglebg|
-4. Terminal Issues			|solarized-term|
+0. Install				|solarized_nvimqt-install|
+1. Solarized_nvimqt Menu			|solarized_nvimqt-menu|
+2. Options				|solarized_nvimqt-options|
+3. Toggle Background			|solarized_nvimqt-togglebg|
+4. Terminal Issues			|solarized_nvimqt-term|
 
 ==============================================================================
-0. Install						*solarized-install*
+0. Install						*solarized_nvimqt-install*
 
 Note: I recommend using Tim Pope's pathogen plugin to install this 
 colorscheme. See https://github.com/tpope/vim-pathogen . If you've installed 
-pathogen properly you can install Solarized with the following commands, 
+pathogen properly you can install Solarized_nvimqt with the following commands, 
 followed by the .vimrc configuration below.
 
 	$ cd ~/.vim/bundle
-	$ git clone https://github.com/altercation/vim-colors-solarized.git
+	$ git clone https://github.com/altercation/vim-colors-solarized_nvimqt.git
 
 If you aren't using pathogen, you can use the following three steps to install 
-Solarized:
+Solarized_nvimqt:
 
-1.  Download the solarized distribution (available on the homepage above)
+1.  Download the solarized_nvimqt distribution (available on the homepage above)
     and unarchive the file.
 
-2.  Move `solarized.vim` to your `.vim/colors` directory.
+2.  Move `solarized_nvimqt.vim` to your `.vim/colors` directory.
 
 3.  Move each of the files in each subdirectories to the corresponding .vim
     subdirectory (e.g. autoload/togglebg.vim goes into your .vim/autoload
@@ -49,39 +49,39 @@ After installation, place the following lines in your .vimrc:
 
 	syntax enable
 	set background=dark
-	colorscheme solarized
+	colorscheme solarized_nvimqt
 
-or, for the light background mode of Solarized:
+or, for the light background mode of Solarized_nvimqt:
 
 	syntax enable
 	set background=light
-	colorscheme solarized
+	colorscheme solarized_nvimqt
 
 ==============================================================================
-1. Solarized Menu					*solarized-menu*
+1. Solarized_nvimqt Menu					*solarized_nvimqt-menu*
 
-Solarized makes available a menu when used in Vim GUI mode (gvim, macvim).  
+Solarized_nvimqt makes available a menu when used in Vim GUI mode (gvim, macvim).  
 This menu includes many of the options detailed below so that you can test out 
 different values quickly without modifying your .vimrc file. If you wish to 
 turn off this menu permanently, simply place the following line in your .vimrc 
-above the "colorscheme solarized" line.
+above the "colorscheme solarized_nvimqt" line.
 
-	let g:solarized_menu=0
+	let g:solarized_nvimqt_menu=0
 
 ==============================================================================
-2. Toggle Background					*solarized-togglebg*
+2. Toggle Background					*solarized_nvimqt-togglebg*
 							*toggle-bg* *togglebg*
 							*toggle-background*
 
-Solarized comes with Toggle Background, a simple plugin to switch between 
+Solarized_nvimqt comes with Toggle Background, a simple plugin to switch between 
 light and dark background modes and reset the colorscheme. This is most useful 
 for colorschemes that support both light and dark modes and in terminals or 
 gui vim windows where the background will be properly set.
 
 Toggle Background can be accessed by:
 
-    * the Solarized menu (in Vim gui mode)
-    * the Window menu (in Vim gui mode, even if the Solarized menu is off)
+    * the Solarized_nvimqt menu (in Vim gui mode)
+    * the Window menu (in Vim gui mode, even if the Solarized_nvimqt menu is off)
     * the "yin/yang" toolbar button (in Vim gui mode)
     * the default mapping of <F5>
     * custom key mapping you set in your .vimrc (see below)
@@ -105,42 +105,42 @@ REPLACE mode, you will switch to standard insert mode (you will leave the
 overwrite replace mode).
 
 ==============================================================================
-3. Solarized Terminal Issues				*solarized-term*
+3. Solarized_nvimqt Terminal Issues				*solarized_nvimqt-term*
 
-If you are going to use Solarized in Terminal mode (i.e. not in a GUI version 
+If you are going to use Solarized_nvimqt in Terminal mode (i.e. not in a GUI version 
 like gvim or macvim), **please please please** consider setting your terminal 
-emulator's colorscheme to used the Solarized palette. I've included palettes 
+emulator's colorscheme to used the Solarized_nvimqt palette. I've included palettes 
 for some popular terminal emulator as well as Xdefaults in the official 
-Solarized download available from the Solarized homepage listed at the top of 
-this help document. If you use Solarized *without* these colors, Solarized 
+Solarized_nvimqt download available from the Solarized_nvimqt homepage listed at the top of 
+this help document. If you use Solarized_nvimqt *without* these colors, Solarized_nvimqt 
 will need to be told to degrade its colorscheme to a set compatible with the 
 limited 256 terminal palette (whereas by using the terminal's 16 ansi color 
-values, you can set the correct, specific values for the Solarized palette).
+values, you can set the correct, specific values for the Solarized_nvimqt palette).
 
-If you do use the custom terminal colors, solarized.vim should work out of 
+If you do use the custom terminal colors, solarized_nvimqt.vim should work out of 
 the box for you. If you are using a terminal emulator that supports 256 
-colors and don't want to use the custom Solarized terminal colors, you will 
+colors and don't want to use the custom Solarized_nvimqt terminal colors, you will 
 need to use the degraded 256 colorscheme. To do so, simply add the following 
-line *before* the `colorschem solarized` line:
+line *before* the `colorschem solarized_nvimqt` line:
 
-    let g:solarized_termcolors=256
+    let g:solarized_nvimqt_termcolors=256
 
-Again, I recommend just changing your terminal colors to Solarized values 
+Again, I recommend just changing your terminal colors to Solarized_nvimqt values 
 either manually or via one of the many terminal schemes available for import.
 
 ==============================================================================
-4. Solarized Options					*solarized-options*
+4. Solarized_nvimqt Options					*solarized_nvimqt-options*
 
 
 AUTOGENERATE OPTIONS
 
-You can easily modify and experiment with Solarized display options using the 
-Solarized menu when using Vim in gui mode. Once you have things set to your 
+You can easily modify and experiment with Solarized_nvimqt display options using the 
+Solarized_nvimqt menu when using Vim in gui mode. Once you have things set to your 
 liking, you can autogenerate the current option list in a format ready for 
-insertion into your .vimrc file using the Solarized menu "Autogenerate 
+insertion into your .vimrc file using the Solarized_nvimqt menu "Autogenerate 
 Options" command or at the command line with:
 
-    :SolarizedOptions
+    :Solarized_nvimqtOptions
 
 
 OPTION LIST
@@ -149,106 +149,106 @@ Set these in your vimrc file prior to calling the colorscheme.
 
 option name               default     optional
 ------------------------------------------------
-g:solarized_termcolors=   16      |   256
-g:solarized_termtrans =   0       |   1
-g:solarized_degrade   =   0       |   1
-g:solarized_bold      =   1       |   0
-g:solarized_underline =   1       |   0
-g:solarized_italic    =   1       |   0
-g:solarized_contrast  =   "normal"|   "high" or "low"
-g:solarized_visibility=   "normal"|   "high" or "low"
-g:solarized_hitrail   =   0       |   1
-g:solarized_menu      =   1       |   0
+g:solarized_nvimqt_termcolors=   16      |   256
+g:solarized_nvimqt_termtrans =   0       |   1
+g:solarized_nvimqt_degrade   =   0       |   1
+g:solarized_nvimqt_bold      =   1       |   0
+g:solarized_nvimqt_underline =   1       |   0
+g:solarized_nvimqt_italic    =   1       |   0
+g:solarized_nvimqt_contrast  =   "normal"|   "high" or "low"
+g:solarized_nvimqt_visibility=   "normal"|   "high" or "low"
+g:solarized_nvimqt_hitrail   =   0       |   1
+g:solarized_nvimqt_menu      =   1       |   0
 ------------------------------------------------
 
 
 OPTION DETAILS
 
 ------------------------------------------------
-g:solarized_termcolors=   256     |   16		*'solarized_termcolors'*
+g:solarized_nvimqt_termcolors=   256     |   16		*'solarized_nvimqt_termcolors'*
 ------------------------------------------------
 The most important option if you are using vim in terminal (non gui) mode!
-This tells Solarized to use the 256 degraded color mode if running in a 256
+This tells Solarized_nvimqt to use the 256 degraded color mode if running in a 256
 color capable terminal.  Otherwise, if set to `16` it will use the terminal
 emulators colorscheme (best option as long as you've set the emulators colors
-to the Solarized palette).
+to the Solarized_nvimqt palette).
 
-If you are going to use Solarized in Terminal mode (i.e. not in a GUI
+If you are going to use Solarized_nvimqt in Terminal mode (i.e. not in a GUI
 version like gvim or macvim), **please please please** consider setting your
-terminal emulator's colorscheme to used the Solarized palette. I've included
+terminal emulator's colorscheme to used the Solarized_nvimqt palette. I've included
 palettes for some popular terminal emulator as well as Xdefaults in the
-official Solarized download available from:
-http://ethanschoonover.com/solarized . If you use Solarized without these
-colors, Solarized will by default use an approximate set of 256 colors.  It
+official Solarized_nvimqt download available from:
+http://ethanschoonover.com/solarized_nvimqt . If you use Solarized_nvimqt without these
+colors, Solarized_nvimqt will by default use an approximate set of 256 colors.  It
 isn't bad looking and has been extensively tweaked, but it's still not quite
 the real thing.
 
 ------------------------------------------------
-g:solarized_termtrans =   0       |   1			*'solarized_termtrans'*
+g:solarized_nvimqt_termtrans =   0       |   1			*'solarized_nvimqt_termtrans'*
 ------------------------------------------------
-If you use a terminal emulator with a transparent background and Solarized
+If you use a terminal emulator with a transparent background and Solarized_nvimqt
 isn't displaying the background color transparently, set this to 1 and
-Solarized will use the default (transparent) background of the terminal
+Solarized_nvimqt will use the default (transparent) background of the terminal
 emulator. *urxvt* required this in my testing; iTerm2 did not.
 
-Note that on Mac OS X Terminal.app, solarized_termtrans is set to 1 by 
+Note that on Mac OS X Terminal.app, solarized_nvimqt_termtrans is set to 1 by 
 default as this is almost always the best option. The only exception to this 
 is if the working terminfo file supports 256 colors (xterm-256color).
 
 ------------------------------------------------
-g:solarized_degrade   =   0       |   1			*'solarized_degrade'*
+g:solarized_nvimqt_degrade   =   0       |   1			*'solarized_nvimqt_degrade'*
 ------------------------------------------------
-For test purposes only; forces Solarized to use the 256 degraded color mode
+For test purposes only; forces Solarized_nvimqt to use the 256 degraded color mode
 to test the approximate color values for accuracy.
 
 ------------------------------------------------
-g:solarized_bold      =   1       |   0			*'solarized_bold'*
+g:solarized_nvimqt_bold      =   1       |   0			*'solarized_nvimqt_bold'*
 ------------------------------------------------
 ------------------------------------------------
-g:solarized_underline =   1       |   0			*'solarized_underline'*
+g:solarized_nvimqt_underline =   1       |   0			*'solarized_nvimqt_underline'*
 ------------------------------------------------
 ------------------------------------------------
-g:solarized_italic    =   1       |   0			*'solarized_italic'*
+g:solarized_nvimqt_italic    =   1       |   0			*'solarized_nvimqt_italic'*
 ------------------------------------------------
-If you wish to stop Solarized from displaying bold, underlined or
+If you wish to stop Solarized_nvimqt from displaying bold, underlined or
 italicized typefaces, simply assign a zero value to the appropriate
-variable, for example: `let g:solarized_italic=0`
+variable, for example: `let g:solarized_nvimqt_italic=0`
 
 ------------------------------------------------
-g:solarized_contrast  =   "normal"|   "high" or "low"	*'solarized_contrast'*
+g:solarized_nvimqt_contrast  =   "normal"|   "high" or "low"	*'solarized_nvimqt_contrast'*
 ------------------------------------------------
 Stick with normal! It's been carefully tested. Setting this option to high
-or low does use the same Solarized palette but simply shifts some values up
+or low does use the same Solarized_nvimqt palette but simply shifts some values up
 or down in order to expand or compress the tonal range displayed.
 
 ------------------------------------------------
-g:solarized_visibility =  "normal"|   "high" or "low" *'solarized_visibility'*
+g:solarized_nvimqt_visibility =  "normal"|   "high" or "low" *'solarized_nvimqt_visibility'*
 ------------------------------------------------
 Special characters such as trailing whitespace, tabs, newlines, when 
 displayed using ":set list" can be set to one of three levels depending on 
 your needs.
 
 ------------------------------------------------
-g:solarized_hitrail   =   0       |   1			*'solarized_hitrail'*
+g:solarized_nvimqt_hitrail   =   0       |   1			*'solarized_nvimqt_hitrail'*
 ------------------------------------------------
 Visibility can make listchar entities more visible, but if one has set 
 cursorline on, these same listchar values standout somewhat less due to the 
-background color of the cursorline. g:solarized_hitrail enables highlighting 
+background color of the cursorline. g:solarized_nvimqt_hitrail enables highlighting 
 of trailing spaces (only one of the listchar types, but a particularly 
 important one) while in the cursoline in a different manner in order to make 
-them more visible. This may not work consistently as Solarized is using 
+them more visible. This may not work consistently as Solarized_nvimqt is using 
 a pattern match than can be overridden by a more encompassing syntax-native 
 match such as a comment line.
 
 
 ------------------------------------------------
-g:solarized_menu       =  1       |   0			*'solarized_menu'*
+g:solarized_nvimqt_menu       =  1       |   0			*'solarized_nvimqt_menu'*
 ------------------------------------------------
-Solarized includes a menu providing access to several of the above
+Solarized_nvimqt includes a menu providing access to several of the above
 display related options, including contrast and visibility. This allows
 for an easy method of testing different values quickly before settling
 on a final assignment for your .vimrc. If you wish to turn off this menu,
-assign g:solarized_menu a value of 0.
+assign g:solarized_nvimqt_menu a value of 0.
 
 
  vim:tw=78:noet:ts=8:ft=help:norl:


### PR DESCRIPTION
As @josko7452 says, this version doesn't work for Neovim terminal version. 

I propose here a new solution : rename colorscheme to solarized-nvimqt for Neovim-qt (`~/.config/nvim/ginit.vim`), and keep original Solarized colorscheme for Neovim terminal version (`~/.config/nvim/init.vim`). 

What do you think about that ? 

Thinks in advance !
