### PR TITLE
Fix SignColumn issue with neovim

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -9,3 +9,5 @@ neovim with the following:
 Normally this wouldn't work with neovim (as of writing) since `gui_running` is always false during initialisation.
 
 For more info see the original.
+
+All above + it fixes the SignColumn issue referenced here: https://github.com/neomake/neomake/issues/6

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -530,7 +530,7 @@ exe "hi! DiffChange"     .s:fmt_bold   .s:fg_yellow .s:bg_base02 .s:sp_yellow
 exe "hi! DiffDelete"     .s:fmt_bold   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_bold   .s:fg_blue   .s:bg_base02 .s:sp_blue
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0  .s:bg_base02  .s:sp_base0
+hi! link SignColumn LineNr
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet


### PR DESCRIPTION
This is referenced here: https://github.com/neomake/neomake/issues/6
gitgutter and syntastic has workarounds for it, but not every new project will have a workaround for it.